### PR TITLE
GH-20: position not mandatory for animation steps

### DIFF
--- a/src/getSteps.test.ts
+++ b/src/getSteps.test.ts
@@ -33,4 +33,5 @@ test('( 4 , jump-both )', 0, {start: 0, end: 17, count: 4, direction: 'jump-both
 test('( 4 , jump-bo )', 0, 'UnknownStepDirection');
 test('( 4 , jump-both ', 0, 'UnclosedParenthesis');
 test(' 4 , jump-both )', 0, 'NoOpenParenthesis');
-test('( 4 jump-both )', 0, 'NoComma');
+test('( 4 jump-both )', 0, 'UnclosedParenthesis');
+test('( 10 )', 0, {start: 0, end: 6, count: 10, direction: 'end'});

--- a/src/getSteps.ts
+++ b/src/getSteps.ts
@@ -20,26 +20,24 @@ export const getSteps = (
     }
     let end = skip(input, start + 1, isWhiteSpace);
     const count = getNumber(input, end);
+    const value: CSSSteps = {
+        type: 'steps',
+        stepCount: count.value,
+        direction: 'end',
+    };
     end = skip(input, count.end, isWhiteSpace);
-    if (input.codePointAt(end) !== Comma) {
-        throw new Error('NoComma');
+    if (input.codePointAt(end) === Comma) {
+        end = skip(input, end + 1, isWhiteSpace);
+        const direction = getCustomIdent(input, end);
+        if (!StepDirection.has(direction.value)) {
+            throw new Error('UnknownStepDirection', direction.value);
+        }
+        value.direction = direction.value as CSSStepDirection;
+        end = direction.end;
     }
-    end = skip(input, end + 1, isWhiteSpace);
-    const direction = getCustomIdent(input, end);
-    if (!StepDirection.has(direction.value)) {
-        throw new Error('UnknownStepDirection', direction.value);
-    }
-    end = skip(input, direction.end, isWhiteSpace);
+    end = skip(input, end, isWhiteSpace);
     if (input.codePointAt(end) !== CloseParenthesis) {
         throw new Error('UnclosedParenthesis');
     }
-    return {
-        start,
-        end: end + 1,
-        value: {
-            type: 'steps',
-            stepCount: count.value,
-            direction: direction.value as CSSStepDirection,
-        },
-    };
+    return {start, end: end + 1, value};
 };

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,44 @@
+import * as assert from 'assert';
+import {parse} from './index';
+
+const test = (
+    input: string,
+    expected: ReturnType<typeof parse>,
+): void => {
+    console.info(input);
+    assert.deepEqual(parse(input), expected);
+};
+
+test(
+    'play1 .8s steps(10) infinite, play2 .8s steps(10) infinite',
+    [
+        {
+            duration: 800,
+            delay: 'unset',
+            timingFunction: {
+                direction: 'end',
+                stepCount: 10,
+                type: 'steps',
+            },
+            iterationCount: 'infinite',
+            direction: 'unset',
+            fillMode: 'unset',
+            playState: 'unset',
+            name: 'play1',
+        },
+        {
+            duration: 800,
+            delay: 'unset',
+            timingFunction: {
+                direction: 'end',
+                stepCount: 10,
+                type: 'steps',
+            },
+            iterationCount: 'infinite',
+            direction: 'unset',
+            fillMode: 'unset',
+            playState: 'unset',
+            name: 'play2',
+        },
+    ],
+);


### PR DESCRIPTION
https://github.com/hookhookun/parse-animation-shorthand/issues/20#issue-1462999711

> Position is not mandatory for steps ([spec](https://www.w3.org/TR/css-easing-1/#funcdef-step-easing-function-steps), [demo](https://codepen.io/Guilh/pen/MWOwBL)).

1. Added test to reproduce the issue.
2. Made step-position optional.
3. Added test for parse() function in index.ts.